### PR TITLE
Add plugin support and correctly escape commands

### DIFF
--- a/CommandCreator.js
+++ b/CommandCreator.js
@@ -102,7 +102,7 @@ var CommandCreator =
 		
 		var setblock = util.format(CommandCreator.SETBLOCK_COMMAND_FORMAT, 
 		                           x, y, z,
-								   blockName, dataValue, command, autoString);
+								   blockName, dataValue, JSON.stringify(command), autoString);
 								   
 		return setblock;
 	},

--- a/FileParser.js
+++ b/FileParser.js
@@ -104,6 +104,24 @@ var FileParser = (function ()
 				console.log("   -> " + command);
 			}
 		}
+        else if(line[0] == "!")
+        {
+        	var args = line.substr(1).split(" ");
+        	var name = args[0];
+        	var plugin = require("./plugins/" + name + ".js");
+        	
+        	var self = this;
+        	plugin(args.slice(1), function(cmd, conditional)
+        	{
+        		var _conditional = CommandCreator.conditional;
+        		
+        		CommandCreator.conditional = conditional || false;
+        		var command = CommandCreator.addSetblockCommand(cmd);
+        		self.Commands.unshift(command);
+        		
+        		CommandCreator.conditional = _conditional;
+        	});
+        }
     };
 	
     return FileParser;

--- a/FileParser.js
+++ b/FileParser.js
@@ -49,7 +49,7 @@ var FileParser = (function ()
 		for(i=0; i < this.Commands.length; i++)
 		{
 			var command = this.Commands[i];
-			var minecart = util.format("{id:MinecartCommandBlock,Command:%s}", command); 
+			var minecart = util.format("{id:MinecartCommandBlock,Command:%s}", JSON.stringify(command)); 
 			minecarts.push(minecart);
 			//if(this.Debug) console.log(minecart);
 		}

--- a/demo/scoreTp.mcc
+++ b/demo/scoreTp.mcc
@@ -1,0 +1,19 @@
+#setup
+	/scoreboard objectives add tpAmount dummy Tp Amount
+	{"type":"chain"}
+	/scoreboard objectives setdisplay sidebar tpAmount
+	/tellraw @a ["run /scoreboard players set @p tpAmount n\nto get teleported by n blocks"]
+	/tellraw @a {"text":"or click here","clickEvent":{"action":"run_command","value":"/scoreboard players set @p tpAmount 42"}}
+
+# tp
+{"type":"repeating","auto":true}
+	/testfor @p[score_tpAmount_min=1]
+	{"conditional":true}
+		/tellraw @p[score_tpAmount_min=1] ["You will now be tp'ed by ",{"score":{"objective":"tpAmount","name":"@p[score_tpAmount_min=1]"}}]
+		{"type":"chain","conditional":false}
+		/execute @p[score_tpAmount_min=1] ~ ~ ~ summon ArmorStand ~ ~ ~ {Tags:["hasTpScore"]}
+		/scoreboard players operation @e[tag=hasTpScore] tpAmount = @p[score_tpAmount_min=1] tpAmount
+		!scoreTp hasTpScore tpAmount 64 x
+		/tp @p[score_tpAmount_min=1] @e[tag=hasTpScore]
+		/kill @e[tag=hasTpScore]
+		/scoreboard players set @p[score_tpAmount_min=1] tpAmount 0

--- a/plugins/scoreTp.js
+++ b/plugins/scoreTp.js
@@ -1,0 +1,24 @@
+var util = require("util");
+
+module.exports = function(args, command)
+{
+	var entityTag = args[0];
+	var objective = args[1];
+	var axis = args[2];
+	var max = parseInt(args[3]) || 32;
+		
+	var axisFormat = "~%d ~ ~";
+	if(axis == "y")
+		axisFormat = "~ ~%d ~";
+	else if(axis == "z")
+		axisFormat = "~ ~ ~%d";
+		
+	
+	for(var i = max; i >= 1; i /= 2)
+	{
+		i = Math.ceil(i);
+		
+		command(util.format("tp @e[tag=%s,score_%s_min=%d] " + axisFormat, entityTag, objective, i, i));
+		command(util.format("scoreboard players remove @e[tag=%s,score_%s_min=%d] %s %d", entityTag, objective, i, objective, i));
+	}
+};


### PR DESCRIPTION
at the moment i only added one plugin but i am planning to add more and therefore the plugin system should work quite well. Basically you can do `!scoreTp <arguments>` and it will require the file `plugins/scoreTp.js`. Every plugin should export a function that is then called passing `<arguments>` and a function to place a commandblock.
