### PR TITLE
fix bug with the math plugin 

### DIFF
--- a/plugins/math.js
+++ b/plugins/math.js
@@ -129,7 +129,8 @@ module.exports = function(args, command)
 	if(valstack.length > 1)
 		throw new Error("Invalid math expression: " + JSON.stringify(formula));
 	
-	placeOp(resultOp[0], result, valstack[0]);
+	valstack[1] = result;
+	op(resultOp[0]);
 	command("scoreboard objectives add math dummy");
 	
 	statics.forEach(function(val, i)


### PR DESCRIPTION
without this fix expressions of the form `<result> <operator> <constant>` did not work.
e.g. `money.@r += 100` did not work, however `money.@r += money.Notch + 100` did.
