### PR TITLE
Add smelt.addInitCommand for plugins

### DIFF
--- a/BangCommandHelper.js
+++ b/BangCommandHelper.js
@@ -29,6 +29,9 @@ var BangCommandHelper =
 			var command = CommandCreator.addSetblockCommand(cmd);
 			commands.push(command);
 			
+			if(_type == "impulse-chain" || _type == "repeating-chain")
+				_type = "chain";
+			
 			CommandCreator.type = _type;
 			CommandCreator.conditional = _conditional;
 			CommandCreator.auto = _auto;

--- a/BangCommandHelper.js
+++ b/BangCommandHelper.js
@@ -38,6 +38,11 @@ var BangCommandHelper =
 			CommandCreator.executeAs = _executeAs;
 		};
 		
+		var callback_addInitCommand = function(cmd)
+		{
+			commands.push(cmd);
+		};
+		
 		var callback_addSupportModule = function(fileName)
 		{
 			var setupData = self.readPluginFile(name, fileName).toString().trim();
@@ -59,6 +64,7 @@ var BangCommandHelper =
 			settings : Settings.Current,
 			args: args.slice(1),
 			addCommandBlock: callback_addCommandBlock,
+			addInitCommand: callback_addInitCommand,
 			addSupportModule: callback_addSupportModule,
 			setVariable: callback_setVariable,
 			getVariable: callback_getVariable

--- a/plugins/math.js
+++ b/plugins/math.js
@@ -27,6 +27,7 @@ var compileTimeOps = {
 }
 
 var Math = {};
+var statics;
 
 Math.Execute = function(smelt)
 {
@@ -115,7 +116,7 @@ Math.Execute = function(smelt)
 		postfix.push(opstack[i]);
 		
 	var cmds = [];
-	var statics = [];
+	var currStatics = [];
 	var valstack = [];
 	var nextMutable = 0;
 	
@@ -133,17 +134,24 @@ Math.Execute = function(smelt)
 	
 	valstack[1] = result;
 	op(resultOp[0]);
-	smelt.addCommandBlock("scoreboard objectives add math dummy");
 	
-	statics.forEach(function(val, i)
+	if(!statics)
 	{
-		if(statics.indexOf(val) != i)
+		statics = [];
+		smelt.addInitCommand("scoreboard objectives add math dummy");
+	}
+	
+	currStatics.forEach(function(val, i)
+	{
+		if(statics.indexOf(val) != -1 || currStatics.indexOf(val) != i)
 			return;
-		smelt.addCommandBlock([
+		statics.push(val);
+			
+		smelt.addInitCommand([
 			"scoreboard players set",
-			"const" + statics[i],
+			"const" + val,
 			"math",
-			statics[i]
+			val
 		].join(" "));
 	});
 	
@@ -212,7 +220,7 @@ Math.Execute = function(smelt)
 	}
 	function toScore(val)
 	{
-		statics.push(val);
+		currStatics.push(val);
 		return {
 			objective: "math",
 			name: "const" + val,

--- a/plugins/pre.js
+++ b/plugins/pre.js
@@ -1,0 +1,10 @@
+var Pre =
+{
+	Execute : function(smelt)
+	{
+		var cmd = smelt.args.join(" ");
+		smelt.addInitCommand(cmd);
+	}
+}
+
+module.exports = Pre;


### PR DESCRIPTION
- Fix plugin commandblocks directly after a `>{"type":"repeating-chain"}` directive
- Add `smelt.addInitCommand(cmd)` for commands that are executed when the system is installed.
- Add `!pre` BangCommand for executing init commands from a mcc file.
- Use addInitCommand in the math plugin so we dont place `/scoreboard objectives add math` and `/scoreboard players set const42 math 42` everywhere.
